### PR TITLE
Update headponeBluetoothSwap.bat

### DIFF
--- a/headponeBluetoothSwap.bat
+++ b/headponeBluetoothSwap.bat
@@ -1,30 +1,36 @@
 @echo off
 
 rem replace these two variables:
-set TRIGGER_NAME = TRIGGER-NAME-HERE
-set KEY = YOUR-KEY-HERE
+set "TRIGGER_NAME_OFF=TRIGGER-NAME-HERE"
+set "TRIGGER_NAME_ON=TRIGGER-NAME-HERE"
+set "KEY=YOUR-KEY-HERE"
 
 rem set this variable to something longer if windows doesn't auto-connect, for example: 5
-set WAIT_TIME = 3
+set /A "WAIT_TIME=3"
 
 
 rem minimize program
 if not DEFINED IS_MINIMIZED set IS_MINIMIZED=1 && start "" /min "%~dpnx0" %* && exit
 
-rem notify user program is running
-call systemTrayNotification.bat -tooltip info -time 4000 -title "Headphones connecting" -text "Swapping connections" -icon information
+rem notify user program is running //giventool doesnt work on my win10 pc so I'm disabled it
+rem call systemTrayNotification.bat -tooltip info -time 4000 -title "Headphones connecting" -text "Swapping connections" -icon information
 
 rem turn bluetooth off to evoke windows bluetooth auto-connect
-powershell -command .\bluetooth.ps1 -BluetoothStatus Off
+powershell -ExecutionPolicy Bypass -File .\bluetooth.ps1 -BluetoothStatus Off
 
 rem tell phone to disconnect trough IFTTT
-curl -X POST https://maker.ifttt.com/trigger/phoneBluOff/with/key/bYnrI8PJVCZZrol1Kgzdtb
+curl -X POST https://maker.ifttt.com/trigger/%TRIGGER_OFF%/with/key/%KEY%
 
 rem wait for phone to turn off bluetooth (screen must be on)
 timeout /t %WAIT_TIME%
 
 rem turn bluetooth back on; evoking auto-connect functionality
+powershell -ExecutionPolicy Bypass -File .\bluetooth.ps1 -BluetoothStatus On 
 
-powershell -command .\bluetooth.ps1 -BluetoothStatus On
+rem wait for headset to connect before turning bluetooth on phone again
+timeout /t %WAIT_TIME%
+
+rem tell phone to renable BT trough IFTTT
+curl -X POST https://maker.ifttt.com/trigger/%TRIGGER_ON%/with/key/%KEY%
 
 exit


### PR DESCRIPTION
several parts of your original code didn't work on my pc (Windows 10). What I changed is
1) changed variable to work correctly inside of the url
2) add bypass script execution restriction on this specific file
3) reenable bluetooth on phone in case user is using a smartwatch such as myself

overall this is a great workaround to quickly switch the headphone device connection to the pc. thanks for coming up with it